### PR TITLE
fix: remove height attribute to show result list

### DIFF
--- a/src/css/popup.css
+++ b/src/css/popup.css
@@ -84,9 +84,10 @@
 
 html, body {
 	width: 500px;
-	height: 35px;
 	margin: 0;
 	padding: 0;
+	/* hides a resize flash that happens when popup is opened on Firefox */
+	scrollbar-width: none;
 }
 
 body {


### PR DESCRIPTION
**Before**

![image](https://user-images.githubusercontent.com/26769888/149089493-c380be50-c0ac-438c-b419-80c08bdcb8c9.png)


**After**

![image](https://user-images.githubusercontent.com/26769888/149089661-3e5d0596-cc64-4801-a1d6-f0fe17c3f15d.png)

This change doesn't negatively affects Chromium browsers (tested on Edge).